### PR TITLE
Update to miou 0.3.0

### DIFF
--- a/bin/life.ml
+++ b/bin/life.ml
@@ -116,24 +116,24 @@ let rec loop (e, t) term ((dim, n, life) as st) =
       Term.release term
   | Ok `Timer ->
       Term.image term (render dim n life) ;
-      let t = Miou.call_cc timer in
+      let t = Miou.async timer in
       loop (e, t) term (dim, n + 1, step (torus dim) life)
   | Ok (`Mouse ((`Press `Left | `Drag), (x, y), _)) ->
-      let e = Miou.call_cc (open_event % event term) in
+      let e = Miou.async (open_event % event term) in
       loop (e, t) term (dim, n, CSet.add (torus dim (x, y)) life)
   | Ok (`Resize dim) ->
       let life = CSet.map (torus dim) life in
       Term.image term (render dim n life) ;
-      let e = Miou.call_cc (open_event % event term) in
+      let e = Miou.async (open_event % event term) in
       loop (e, t) term (dim, n, life)
   | Ok _ ->
-      let e = Miou.call_cc (open_event % event term) in
+      let e = Miou.async (open_event % event term) in
       loop (e, t) term st
 
 let main () =
   let term = Term.create () in
-  let e = Miou.call_cc (open_event % event term) in
-  let t = Miou.call_cc timer in
+  let e = Miou.async (open_event % event term) in
+  let t = Miou.async timer in
   loop (e, t) term (Term.size term, 0, glider)
 
 let () = Miou_unix.run main

--- a/lib/nottui_miou.ml
+++ b/lib/nottui_miou.ml
@@ -36,8 +36,8 @@ let render ~size ~stop ~events v =
     in
     do_event ()
   in
-  let prm0 = Miou.call_cc do_refresh in
-  let prm1 = Miou.call_cc do_event in
+  let prm0 = Miou.async do_refresh in
+  let prm1 = Miou.async do_event in
   Stream.put refresh ();
   (image, prm0, prm1)
 
@@ -55,7 +55,7 @@ let run v =
     Term.image term image;
     do_print ()
   in
-  let prm2 = Miou.call_cc do_print in
-  let prm3 = Miou.call_cc @@ fun () -> Stop.wait stop in
+  let prm2 = Miou.async do_print in
+  let prm3 = Miou.async @@ fun () -> Stop.wait stop in
   or_raise $ Miou.await_first [ prm0; prm1; prm2; prm3 ];
   Term.release term

--- a/notty-miou.opam
+++ b/notty-miou.opam
@@ -16,6 +16,3 @@ depends: [
   "notty" {>= "0.2.3"}
   "miou"
 ]
-pin-depends: [
-  "miou.dev" "git+https://github.com/robur-coop/miou.git#c6304756eaa63aeabb3cfdd2387f77c300856fca"
-]


### PR DESCRIPTION
- Use `Miou.async` instead of the old `Miou.call_cc`
- Change `Miou_unix.read input buf 0 (Bytes.length buf)` to `Miou_unix.read input buf` (as `off` and `len` become optional arguments)